### PR TITLE
Add protected header to seal and open with json serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,18 @@ it('encrypt / decrypt', async () => {
   const plaintext = new TextEncoder().encode(message);
   const ciphertext = await hpke.json.encrypt(plaintext, publicKeyJwk)
   // {
+  //   "protected": "eyJhbGciOiJIUEtFLUJhc2UtUDI1Ni1TSEEyNTYtQUVTMTI4R0NNIiwiZW5jIjoiQUVTMTI4R0NNIn0",
   //   "unprotected": {
   //     "recipients": [
   //       {
-  //         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:5QPavpXFqMyRfGw6uocROgobSyjyrhPdo5SllaZ-Nvo",
-  //         "encapsulated_key": "BCVMwqZyG2dV0ghOnvLUjbRsZH9rOa-qYAfimsOs_Bk4jUSuSIsqz-u66zNEw0papvR8SEn3oPkV7qDb2KxQTJ4",
-  //         "encrypted_key": "dViGsJMkfIDvdqbtfHx3l2oaQ-6ONU890oPyOwmTOOQ"
+  //         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:mkyymiz-41bn2xNKdui5eDJ9dIVJhJk5FWqU3Ar3ZSo",
+  //         "encapsulated_key": "BKScRMMcR_keKyLI6MD-PiVgj31Y5pU1NETRIIXn_6xRBuYmB3A1plI73KvhUBciggpupz99u2Xd8c2Ba_4A3tk",
+  //         "encrypted_key": "aGUXW752It4SPyTBHvAFOD-p2bn9H__6Z1gdzxoFUTA"
   //       }
   //     ]
   //   },
-  //   "iv": "QT9drgDCaosnyQei",
-  //   "ciphertext": "6nQLs8bXUh0vHjSk_q4-eu4XJVXdx_AUZeQpDpnnbPguVjS1aYQjPfG9qIZ1zKm9k0Fh7eL5lgyzbyA8OgmPGVa8EooEl1H9bvmnib6jzP9H4A"
+  //   "iv": "27oAybln9XY8_jlO",
+  //   "ciphertext": "cNOYxd9u0bQA-iu6P9ngRToMOdvkuUVdoX4eFsUwVVvUDWuHRCxiuFGMP3a3z1EStSR6XwWKD_llC3mTLFfs52L9gAsNQN6uInzAiz5GYMoiRw"
   // }
   const recovered = await hpke.json.decrypt(ciphertext, privateKeyJwk)
   expect(new TextDecoder().decode(recovered)).toBe(message);

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ it('encrypt / decrypt', async () => {
   //   "unprotected": {
   //     "recipients": [
   //       {
-  //         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:mkyymiz-41bn2xNKdui5eDJ9dIVJhJk5FWqU3Ar3ZSo",
-  //         "encapsulated_key": "BKScRMMcR_keKyLI6MD-PiVgj31Y5pU1NETRIIXn_6xRBuYmB3A1plI73KvhUBciggpupz99u2Xd8c2Ba_4A3tk",
-  //         "encrypted_key": "aGUXW752It4SPyTBHvAFOD-p2bn9H__6Z1gdzxoFUTA"
+  //         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:6t9Wc2xlUkpk__8PCh1rw6l4y_TGkMMDr0G8MHz-_Go",
+  //         "encapsulated_key": "BEF-wTOaVPl2Txtq5pAz0HKJIMvU81mo5fw6TSvvB4X_ztF_StJj_M5TjEND-UovepiN9R4SNVTCCsagGtvDcf4",
+  //         "encrypted_key": "l9glJQCkjjHCANciamXRxPxiGO7hM7nuU4wIC-dhojA"
   //       }
   //     ]
   //   },
-  //   "iv": "27oAybln9XY8_jlO",
-  //   "ciphertext": "cNOYxd9u0bQA-iu6P9ngRToMOdvkuUVdoX4eFsUwVVvUDWuHRCxiuFGMP3a3z1EStSR6XwWKD_llC3mTLFfs52L9gAsNQN6uInzAiz5GYMoiRw"
+  //   "iv": "chl5-N9n-MDlLP8W",
+  //   "ciphertext": "kK1dSmkmhJgKBpVdrKOKyz5oUQd6km6_8PagQ_WfpN0lRzbmgBCr6mIrOXojVwVIKRTqNzvuTcFNrzxXtDbzra42DMQ_aTUX8xSc87V-7fHMzw"
   // }
   const recovered = await hpke.json.decrypt(ciphertext, privateKeyJwk)
   expect(new TextDecoder().decode(recovered)).toBe(message);

--- a/src/ContentEncryption.ts
+++ b/src/ContentEncryption.ts
@@ -1,0 +1,51 @@
+
+import crypto from 'crypto'
+
+export const generateContentEncryptionKey = (enc: string) => {
+  if (enc == 'A128GCM') {
+    const contentEncryptionKey = crypto.randomBytes(16) // possibly wrong
+    return contentEncryptionKey;
+  }
+  throw new Error('Unsupported content encryption algorithm')
+}
+
+export const encryptContent = async (
+  enc: string,
+  plaintext: Uint8Array,
+  initializationVector: Uint8Array,
+  additionalData: Uint8Array | undefined,
+  contentEncryptionKey: Uint8Array
+) => {
+  if (enc !== 'A128GCM') {
+    throw new Error('encryption algorithm not supported.')
+  }
+  const key = await crypto.subtle.importKey('raw', contentEncryptionKey, {
+    name: "AES-GCM",
+  }, true, ["encrypt", "decrypt"])
+  const encrypted_content = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: initializationVector, additionalData },
+    key,
+    plaintext,
+  );
+  return new Uint8Array(encrypted_content)
+}
+
+export const decryptContent = async (enc: string,
+  ciphertext: Uint8Array,
+  initializationVector: Uint8Array,
+  additionalData: Uint8Array | undefined,
+  contentEncryptionKey: Uint8Array
+) => {
+  if (enc !== 'A128GCM') {
+    throw new Error('encryption algorithm not supported.')
+  }
+  const key = await crypto.subtle.importKey('raw', contentEncryptionKey, {
+    name: "AES-GCM",
+  }, true, ["encrypt", "decrypt"])
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: initializationVector, additionalData },
+    key,
+    ciphertext,
+  );
+  return new Uint8Array(plaintext)
+}

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -3,10 +3,52 @@ import crypto from 'crypto';
 
 import { generateKeyPair, exportJWK, calculateJwkThumbprintUri } from "jose"
 
-export type DEFAULT_ALG = 'HPKE-Base-P256-SHA256-AES128GCM'
+import { AeadId, CipherSuite, KdfId, KemId } from "hpke-js";
 
-export const default_alg: DEFAULT_ALG = 'HPKE-Base-P256-SHA256-AES128GCM'
+export type JOSE_HPKE_ALG = `HPKE-Base-P256-SHA256-AES128GCM` | `HPKE-Base-P384-SHA256-AES128GCM`
 
+export type JWK = {
+  kid?:string
+  alg?: string
+  kty: string
+}
+
+export type JWKS = {
+  keys: JWK[]
+}
+
+export type HPKERecipient = {
+  kid?: string
+  encapsulated_key: string,
+  encrypted_key: string
+}
+
+
+export const suites = {
+  ['HPKE-Base-P256-SHA256-AES128GCM']: new CipherSuite({
+    kem: KemId.DhkemP256HkdfSha256,
+    kdf: KdfId.HkdfSha256,
+    aead: AeadId.Aes128Gcm,
+  }),
+  ['HPKE-Base-P384-SHA256-AES128GCM']: new CipherSuite({
+    kem: KemId.DhkemP384HkdfSha384,
+    kdf: KdfId.HkdfSha256,
+    aead: AeadId.Aes128Gcm,
+  })
+}
+
+// // HPKE-Base-P256-SHA256-AES128GCM -> A128GCM
+// const algToEnc = (alg: string) => {
+//   const aead = `${alg.split('-').pop()}`;
+//   if (aead === 'AES128GCM'){
+//     return 'A128GCM'
+//   }
+// }
+
+export const isKeyAlgorithmSupported = (recipient: JWK) => {
+  const supported_alg = Object.keys(suites) as string []
+  return supported_alg.includes(`${recipient.alg}`)
+}
 
 const formatJWK = (jwk: any) => {
   const { kid, alg, kty, crv, x, y, d } = jwk
@@ -50,12 +92,19 @@ export const privateKeyFromJwk = async (privateKeyJwk: any)=>{
   return privateKey
 }
 
-export const generate = async (alg: DEFAULT_ALG) => {
-  if (alg !== default_alg){
-    throw new Error('Only supported algorithm is: ' + default_alg)
+export const generate = async (alg: JOSE_HPKE_ALG) => {
+  if (!suites[alg]){
+    throw new Error('Algorithm not supported')
   }
-  const { privateKey } = await generateKeyPair('ECDH-ES+A256KW', { crv: 'P-256', extractable: true })
-  const privateKeyJwk = await exportJWK(privateKey);
+  let kp;
+  if (alg.includes('P256')){
+    kp = await generateKeyPair('ECDH-ES+A256KW', { crv: 'P-256', extractable: true })
+  } else if (alg.includes('P384')){
+    kp = await generateKeyPair('ECDH-ES+A256KW', { crv: 'P-384', extractable: true })
+  } else {
+    throw new Error('Could not generate private key for ' + alg)
+  }
+  const privateKeyJwk = await exportJWK(kp.privateKey);
   privateKeyJwk.kid = await calculateJwkThumbprintUri(privateKeyJwk)
   privateKeyJwk.alg = alg;
   return formatJWK(privateKeyJwk)

--- a/tests/json.test.ts
+++ b/tests/json.test.ts
@@ -2,24 +2,47 @@
 import * as hpke from '../src'
 
 it('encrypt / decrypt', async () => {
-  const privateKeyJwk = await hpke.keys.generate('HPKE-Base-P256-SHA256-AES128GCM')
-  const publicKeyJwk = await hpke.keys.publicFromPrivate(privateKeyJwk)
+  // recipient 1
+  const privateKey1 = await hpke.keys.generate('HPKE-Base-P256-SHA256-AES128GCM')
+  const publicKey1 = await hpke.keys.publicFromPrivate(privateKey1)
+
+  // recipient 2
+  const privateKey2 = await hpke.keys.generate('HPKE-Base-P256-SHA256-AES128GCM')
+  const publicKey2 = await hpke.keys.publicFromPrivate(privateKey2)
+
+  const resolvePrivateKey = (kid: string) =>{
+    if (kid === publicKey1.kid){
+      return privateKey1
+    }
+    if (kid === publicKey2.kid){
+      return privateKey2
+    }
+    throw new Error('Unknown kid')
+  }
+
+  // recipients as a JWKS
+  const recipientPublicKeys = {
+    "keys" : [
+      publicKey1,
+      publicKey2
+    ]
+  }
+
   const message = `It’s a 💀 dangerous business 💀, Frodo, going out your door.`
   const plaintext = new TextEncoder().encode(message);
-  const ciphertext = await hpke.json.encrypt(plaintext, publicKeyJwk)
-  // {
-  //   "unprotected": {
-  //     "recipients": [
-  //       {
-  //         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:5QPavpXFqMyRfGw6uocROgobSyjyrhPdo5SllaZ-Nvo",
-  //         "encapsulated_key": "BCVMwqZyG2dV0ghOnvLUjbRsZH9rOa-qYAfimsOs_Bk4jUSuSIsqz-u66zNEw0papvR8SEn3oPkV7qDb2KxQTJ4",
-  //         "encrypted_key": "dViGsJMkfIDvdqbtfHx3l2oaQ-6ONU890oPyOwmTOOQ"
-  //       }
-  //     ]
-  //   },
-  //   "iv": "QT9drgDCaosnyQei",
-  //   "ciphertext": "6nQLs8bXUh0vHjSk_q4-eu4XJVXdx_AUZeQpDpnnbPguVjS1aYQjPfG9qIZ1zKm9k0Fh7eL5lgyzbyA8OgmPGVa8EooEl1H9bvmnib6jzP9H4A"
-  // }
-  const recovered = await hpke.json.decrypt(ciphertext, privateKeyJwk)
-  expect(new TextDecoder().decode(recovered)).toBe(message);
+  const contentEncryptionAlgorithm = 'A128GCM'
+
+  const ciphertext = await hpke.json.encrypt(contentEncryptionAlgorithm, plaintext, recipientPublicKeys)
+
+  // console.log(JSON.stringify(ciphertext, null, 2))
+
+  for (const recipient of recipientPublicKeys.keys){
+    const privateKey = resolvePrivateKey(recipient.kid)
+    // simulate having only one of the recipient private keys
+    const recipientPrivateKeys =  { "keys": [ privateKey ] }
+
+    const recovered = await hpke.json.decrypt(ciphertext, recipientPrivateKeys)
+    expect(new TextDecoder().decode(recovered)).toBe(message);
+  }
+  
 })


### PR DESCRIPTION
This PR:
- adds a protected header to the json serialization for HPKE JWE.
- uses the protected header as `aad` for both seal and open HPKE operations
- uses the protected header as `aad` for both encrypt and decrypt content encryption operations
